### PR TITLE
ci: oxfmt format — green main

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -5,6 +5,7 @@
     "**/dist/**",
     "**/build/**",
     "**/storybook-static/**",
-    "**/migrations/**"
+    "**/migrations/**",
+    "**/*.sarif"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,12 +13,12 @@ This is a **bun-workspace monorepo** wrapped by **Nx** (task graph + enforced bo
 
 **Three buckets are what you RUN; a fourth (`packages/`) is what you SHIP.**
 
-| Folder       | Role                                | Served?                          | Examples                                                                                                                      |
-| ------------ | ----------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `apps/`      | what **humans** see                 | public UI                        | `@stack/web` (Next.js), `@stack/landing` (marketing), `@stack/mobile` (Expo/React Native)                                     |
-| `services/`  | what has a **URL** / its own deploy | served to other code             | `@stack/api` (Hono + OpenAPI), `@stack/payment` (Creem adapter), `@stack/ai-worker` (background, no URL)                      |
-| `libs/`      | **shared** code                     | **never served** — consumed only | `@stack/ui`, `@stack/auth`, `@stack/db`, `@stack/ai`, `@stack/analytics`, `@stack/email`, `@stack/config`, `@stack/api-types` |
-| `packages/`  | what you **ship** — a distributable | served to **third parties**      | `@stack/widget` (embeddable widget: IIFE `<script src>` + ESM); npm SDKs and CLIs live here too                              |
+| Folder      | Role                                | Served?                          | Examples                                                                                                                      |
+| ----------- | ----------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `apps/`     | what **humans** see                 | public UI                        | `@stack/web` (Next.js), `@stack/landing` (marketing), `@stack/mobile` (Expo/React Native)                                     |
+| `services/` | what has a **URL** / its own deploy | served to other code             | `@stack/api` (Hono + OpenAPI), `@stack/payment` (Creem adapter), `@stack/ai-worker` (background, no URL)                      |
+| `libs/`     | **shared** code                     | **never served** — consumed only | `@stack/ui`, `@stack/auth`, `@stack/db`, `@stack/ai`, `@stack/analytics`, `@stack/email`, `@stack/config`, `@stack/api-types` |
+| `packages/` | what you **ship** — a distributable | served to **third parties**      | `@stack/widget` (embeddable widget: IIFE `<script src>` + ESM); npm SDKs and CLIs live here too                               |
 
 The first three are **what you RUN** — sorted by _who they're served to_ (your humans, your machines, your own code). `packages/` is the odd one out: **what you SHIP** — a built artifact exposed to people _outside_ your system (published to npm, embedded on a customer's site). Its tag is `type:package`; it may depend on `libs/*` only, and it's **terminal — nothing internal imports a package** (§3, law 9). If you ship nothing external, delete the folder.
 
@@ -135,13 +135,13 @@ cp .env.example .env.local
 
 ## 5. Adding things — the decision
 
-| You need…                         | Put it in                | Then                                                                                                                                     |
-| --------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| shared code used in 2+ places     | a new `libs/*` package   | scaffold with the Nx generator: `nx g @nx/js:lib …` — it's born tagged `type:lib`, named `@stack/*`, with its single `src/index.ts` door |
-| something with its own URL/deploy | a new `services/*`       | scaffold, then add a `local_resource` to `.devops/Tiltfile`; skill: `agents/skills/add-a-service`                                        |
-| a new user-facing surface         | a new `apps/*`           | scaffold, then wire it into `.devops/Tiltfile`                                                                                           |
-| a distributable to ship out (npm SDK, embed widget, CLI) | a new `packages/*` | tag `type:package`, build to `dist/` (IIFE + ESM), depends on libs only, terminal. Recipe: [`docs/packages.md`](./docs/packages.md); worked example: `packages/widget` |
-| a new payment provider            | `@stack/payment` adapter | never inline in an app; skill: `agents/skills/wire-a-new-payment-provider`                                                               |
+| You need…                                                | Put it in                | Then                                                                                                                                                                   |
+| -------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| shared code used in 2+ places                            | a new `libs/*` package   | scaffold with the Nx generator: `nx g @nx/js:lib …` — it's born tagged `type:lib`, named `@stack/*`, with its single `src/index.ts` door                               |
+| something with its own URL/deploy                        | a new `services/*`       | scaffold, then add a `local_resource` to `.devops/Tiltfile`; skill: `agents/skills/add-a-service`                                                                      |
+| a new user-facing surface                                | a new `apps/*`           | scaffold, then wire it into `.devops/Tiltfile`                                                                                                                         |
+| a distributable to ship out (npm SDK, embed widget, CLI) | a new `packages/*`       | tag `type:package`, build to `dist/` (IIFE + ESM), depends on libs only, terminal. Recipe: [`docs/packages.md`](./docs/packages.md); worked example: `packages/widget` |
+| a new payment provider                                   | `@stack/payment` adapter | never inline in an app; skill: `agents/skills/wire-a-new-payment-provider`                                                                                             |
 
 Prefer the Nx generators — a generated package **can't be born breaking the boundary laws** (it's tagged and has its barrel from birth). Commands: [`docs/nx.md`](./docs/nx.md).
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ See [`docs/portless.md`](./docs/portless.md) for the full convention.
 
 ## The map — three folders, defined by exposure
 
-| Folder          | Role                                                                | Served?                          |
-| --------------- | ------------------------------------------------------------------- | -------------------------------- |
-| **`apps/`**     | what humans see (web, landing, mobile, **blog**)                         | public UI                        |
-| **`services/`** | what has a URL (api, ai-worker, payment)                                 | served to other code             |
-| **`libs/`**     | shared code (ui, auth, db, ai, config, api-types, analytics, email, seo) | **never served** — consumed only |
+| Folder          | Role                                                                     | Served?                                |
+| --------------- | ------------------------------------------------------------------------ | -------------------------------------- |
+| **`apps/`**     | what humans see (web, landing, mobile, **blog**)                         | public UI                              |
+| **`services/`** | what has a URL (api, ai-worker, payment)                                 | served to other code                   |
+| **`libs/`**     | shared code (ui, auth, db, ai, config, api-types, analytics, email, seo) | **never served** — consumed only       |
 | **`packages/`** | what you **ship** — distributables (widget; npm SDKs, CLIs)              | served to **third parties** — terminal |
 
 The first three are **what you RUN**; `packages/` is **what you SHIP** — a built artifact (`type:package`) that leaves the repo (published/embedded), depends on `libs/*` only, and that nothing internal imports.

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -42,23 +42,23 @@ From our own security vetting. Three tiers. **Scan every one before install** (`
 
 Safe to draw from for a public starter. Cherry-pick; don't bulk-import.
 
-| Skill | Why | Note |
-| --- | --- | --- |
-| **`anthropics/*`** (official) | First-party, maintained, lowest supply-chain risk. **Start here for anything they cover.** | — |
-| **`coreyhaines31/marketingskills`** | MIT, clean, well-scoped. Marketing/GTM is the developer weak spot — this fills it. | **Cherry-pick a few** (cold-email, CRO, SEO-audit) — don't dump all ~50. |
-| **`mattpocock/skills`** | Testing + TypeScript, from a reputable author. | — |
-| **`trailofbits/skills`** | Security review / code-audit — **the gold standard**. | **CC-BY-SA** — preserve attribution if you redistribute. |
-| **`ui-ux-pro-max`** — data-CSV knowledge base **only** | The CSV knowledge base is inert data, low-risk, useful. | Take **only** the data-CSV part; the full bundle is Tier 2. |
+| Skill                                                  | Why                                                                                        | Note                                                                     |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| **`anthropics/*`** (official)                          | First-party, maintained, lowest supply-chain risk. **Start here for anything they cover.** | —                                                                        |
+| **`coreyhaines31/marketingskills`**                    | MIT, clean, well-scoped. Marketing/GTM is the developer weak spot — this fills it.         | **Cherry-pick a few** (cold-email, CRO, SEO-audit) — don't dump all ~50. |
+| **`mattpocock/skills`**                                | Testing + TypeScript, from a reputable author.                                             | —                                                                        |
+| **`trailofbits/skills`**                               | Security review / code-audit — **the gold standard**.                                      | **CC-BY-SA** — preserve attribution if you redistribute.                 |
+| **`ui-ux-pro-max`** — data-CSV knowledge base **only** | The CSV knowledge base is inert data, low-risk, useful.                                    | Take **only** the data-CSV part; the full bundle is Tier 2.              |
 
 ### Tier 2 — Link-only / scan-first / opt-in (great but heavy or hook-installing)
 
 Genuinely good, but **install them yourself — don't bake them into the template.** Weight or auto-executing behavior makes them a per-user choice, not a default.
 
-| Skill | Why link-only |
-| --- | --- |
-| **`pbakaus/impeccable`** | Excellent design skill — but **~124 MB**, **auto-firing post-edit hooks**, and a **daily phone-home version check**. All fine if _you_ opt in; wrong to impose on every cloner. |
-| **the full `ui-ux` bundle** | Heavy; only the data-CSV slice (Tier 1) is lightweight enough to recommend outright. |
-| **Snyk Fix** | Strong, but needs the **Snyk MCP** wired up — an external dependency, so it's opt-in per user. |
+| Skill                       | Why link-only                                                                                                                                                                   |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`pbakaus/impeccable`**    | Excellent design skill — but **~124 MB**, **auto-firing post-edit hooks**, and a **daily phone-home version check**. All fine if _you_ opt in; wrong to impose on every cloner. |
+| **the full `ui-ux` bundle** | Heavy; only the data-CSV slice (Tier 1) is lightweight enough to recommend outright.                                                                                            |
+| **Snyk Fix**                | Strong, but needs the **Snyk MCP** wired up — an external dependency, so it's opt-in per user.                                                                                  |
 
 ### Tier 3 — Reject for a public starter
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -26,7 +26,7 @@ Pulling a chunk of existing code into a new workspace package is the same recipe
    ```jsonc
    {
      "name": "@stack/db",
-     "exports": { ".": "./src/index.ts" }
+     "exports": { ".": "./src/index.ts" },
    }
    ```
 4. **Map the path** in `tsconfig.base.json` — the `./`-prefixed entry (there's no `baseUrl`; a bare `libs/…` throws TS5090, and Nx needs this path to resolve `@stack/*` for the boundary rule):
@@ -35,7 +35,7 @@ Pulling a chunk of existing code into a new workspace package is the same recipe
    ```
 5. **Tag it** for the boundary rule — `nx.tags` in the same `package.json`:
    ```jsonc
-   { "nx": { "tags": ["type:lib"] } }   // or type:service / type:app
+   { "nx": { "tags": ["type:lib"] } } // or type:service / type:app
    ```
 
 Then rewrite the imports at the call sites: `../../lib/db` becomes `@stack/db`. Because everything now enters through one door, that's a flat find-and-replace, not a path-chasing exercise.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -38,7 +38,7 @@ Prove it yourself: `packages/widget` imports `@stack/ui/tokens` (a legal
    `publishConfig`. Depend on `libs/*` only.
 3. **Build to `dist/`** — a `build` script producing your outputs. For an embeddable
    widget that's **two**: an **IIFE** (`esbuild src/embed.ts --bundle --format=iife
-   --minify`) for a `<script src>` on any site, and an **ESM** build
+--minify`) for a `<script src>` on any site, and an **ESM** build
    (`--format=esm`) for npm consumers. A CLI/SDK may need only one. `dist/` is
    gitignored — it's a build artifact.
 4. **`tsconfig.base.json` `paths`** — add `"@stack/<name>": ["./packages/<name>/src/index.ts"]`


### PR DESCRIPTION
Fixes the only failing CI step on `main` (Format check / oxfmt) — whitespace/table-alignment on 5 docs files. `oxfmt --check` + `bun install --frozen-lockfile` pass. Base for the deps + ops merges.