### PR TITLE
chore(tilt): BUILDERS-STACK dashboard banner

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -9,11 +9,12 @@ load_dynamic('.devops/Tiltfile')
 
 # =============================================================================
 # Dashboard "title" — Tilt has no native project-title setting, so a banner
-# resource in its own CAPITALIZED label group (capitals sort before lowercase)
-# headlines the sidebar with the project name. Cosmetic, zero-cost.
+# resource in a digit-prefixed label group (Tilt sorts groups case-insensitively,
+# so a leading digit is the only thing that sorts above the alphabet) headlines
+# the sidebar with the project name. Cosmetic, zero-cost.
 # =============================================================================
 local_resource(
     'BUILDERS-STACK',
     cmd='echo "🏗️  Builders Stack — the shared TS-backend template dashboard · ./tilt_up.sh · UI :10380"',
-    labels=['BUILDERS-STACK'],
+    labels=['0-BUILDERS-STACK'],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -6,3 +6,14 @@
 # See docs/portless.md.
 
 load_dynamic('.devops/Tiltfile')
+
+# =============================================================================
+# Dashboard "title" — Tilt has no native project-title setting, so a banner
+# resource in its own CAPITALIZED label group (capitals sort before lowercase)
+# headlines the sidebar with the project name. Cosmetic, zero-cost.
+# =============================================================================
+local_resource(
+    'BUILDERS-STACK',
+    cmd='echo "🏗️  Builders Stack — the shared TS-backend template dashboard · ./tilt_up.sh · UI :10380"',
+    labels=['BUILDERS-STACK'],
+)


### PR DESCRIPTION
Adds a cosmetic banner `local_resource` in its own CAPITALIZED label group so it sorts to the top of the Tilt sidebar and names the dashboard (Tilt has no native project-title setting). Zero-cost, dev-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)