### PR TITLE
feat(web): social sign-in via popup with redirect fallback

### DIFF
--- a/apps/web/app/auth/auth-client.ts
+++ b/apps/web/app/auth/auth-client.ts
@@ -2,7 +2,8 @@ import { createAuthClient } from "better-auth/react";
 
 // baseURL = the API origin. Better Auth appends its default basePath (/api/auth),
 // so requests land on @stack/api's /api/auth/* handler. Configurable, local default.
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+// Exported so the social popup flow can POST /sign-in/social directly (see auth/page.tsx).
+export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
 export const authClient = createAuthClient({
   baseURL: API_URL,
@@ -12,4 +13,4 @@ export const authClient = createAuthClient({
   fetchOptions: { credentials: "include" },
 });
 
-export const { signIn, signUp, signOut, useSession } = authClient;
+export const { signIn, signUp, signOut, useSession, getSession } = authClient;

--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -13,7 +13,11 @@ import {
   Input,
   Label,
 } from "@stack/ui";
-import { signIn, signUp } from "./auth-client";
+import { signIn, signUp, getSession, API_URL } from "./auth-client";
+
+// The social provider the @stack/api server configures (libs/auth: socialProviders).
+// The template ships GitHub; a clone swaps this + the server provider together.
+const SOCIAL_PROVIDER = "github";
 
 type Mode = "sign-in" | "sign-up";
 
@@ -45,6 +49,73 @@ export default function AuthPage() {
     setPending(false);
   }
 
+  // Social sign-in via the house popup pattern (kept textually in sync with krispy's
+  // apps/web/app/_components/AuthForm.tsx onGoogle — divergences: provider name +
+  // @stack/ui primitives + the "stack-oauth-done" channel).
+  async function onSocial() {
+    setError(null);
+
+    // Open a blank popup synchronously inside the click gesture — desktop keeps the
+    // user on the sign-in page while the provider loads in the popup. Mobile browsers
+    // block popups, so window.open returns null and we fall back to a full-page redirect.
+    const width = 500;
+    const height = 600;
+    const left = window.screenX + (window.outerWidth - width) / 2;
+    const top = window.screenY + (window.outerHeight - height) / 2;
+    const popup = window.open(
+      "",
+      "stack-social-auth",
+      `width=${width},height=${height},left=${left},top=${top},popup=yes`,
+    );
+
+    // Ask Better Auth for the OAuth URL WITHOUT redirecting this page. Cross-origin
+    // (web → api) with credentials so the eventual session cookie sticks; callbackURL
+    // is a WEB-origin page (trustedOrigins allows it) that closes the popup.
+    const callbackURL = `${window.location.origin}/auth/popup-complete`;
+    let url: string | undefined;
+    try {
+      const res = await fetch(`${API_URL}/api/auth/sign-in/social`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ provider: SOCIAL_PROVIDER, callbackURL, disableRedirect: true }),
+      });
+      url = res.ok ? (await res.json().catch(() => null))?.url : undefined;
+    } catch {
+      /* network / offline — handled by the !url guard below */
+    }
+
+    if (!url) {
+      popup?.close();
+      // Popup path failed to get a URL: fall back to the redirect flow, which surfaces
+      // any real error through onError on this page.
+      await signIn.social(
+        { provider: SOCIAL_PROVIDER, callbackURL: "/" },
+        {
+          onError: (ctx: { error: { message?: string } }) =>
+            setError(ctx.error.message ?? "Something went wrong."),
+        },
+      );
+      return;
+    }
+
+    if (popup) {
+      // Desktop popup flow: the callback page broadcasts "done"; we revalidate the
+      // session (no full reload) so the useSession gate swaps in the signed-in view.
+      const bc = new BroadcastChannel("stack-oauth-done");
+      bc.onmessage = () => {
+        bc.close();
+        void getSession();
+        router.push("/");
+      };
+      popup.location.href = url;
+    } else {
+      // Popup blocked (mobile): full-page redirect. The callback page has no opener,
+      // so it navigates itself home.
+      window.location.href = url;
+    }
+  }
+
   const isSignUp = mode === "sign-up";
 
   return (
@@ -58,6 +129,14 @@ export default function AuthPage() {
             </CardDescription>
           </CardHeader>
           <CardContent className="flex flex-col gap-4">
+            <Button type="button" variant="outline" className="w-full" onClick={onSocial}>
+              Continue with GitHub
+            </Button>
+            <div className="flex items-center gap-3">
+              <span className="h-px flex-1 bg-border" />
+              <span className="text-xs uppercase text-muted-foreground">or</span>
+              <span className="h-px flex-1 bg-border" />
+            </div>
             {isSignUp && (
               <div className="flex flex-col gap-2">
                 <Label htmlFor="name">Name</Label>

--- a/apps/web/app/auth/popup-complete/page.tsx
+++ b/apps/web/app/auth/popup-complete/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Where Better Auth lands the browser after social OAuth completes (passed as
+// `callbackURL` from the auth page — a WEB-origin page, so the session cookie for the
+// api origin is already set by the time we get here).
+//
+// Popup flow: signal the opener that OAuth is done, then close ourselves. We use
+// BroadcastChannel (not postMessage / popup.closed polling) because COOP isolates
+// the opener from the popup — same-origin BroadcastChannel is the reliable channel.
+// Redirect flow (popup was blocked): we ARE the main window, so just go home; the
+// gate revalidates the session on mount.
+export default function PopupComplete() {
+  useEffect(() => {
+    if (window.opener) {
+      const bc = new BroadcastChannel("stack-oauth-done");
+      bc.postMessage("done");
+      bc.close();
+      window.close();
+    } else {
+      window.location.href = "/";
+    }
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-md">
+      <p className="text-sm text-muted-foreground">One moment…</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds a **GitHub social sign-in button** to the web auth page using the **house popup pattern**, so clones of this template inherit the popup flow rather than a full-page OAuth redirect. Email/password sign-in/up is untouched.

## Why this shape

Ported from the krispy `apps/web/app/_components/AuthForm.tsx` `onGoogle` (itself from the production-proven adimoyal toolkit). The template previously had **no social button** in the UI, and `libs/auth` configures **GitHub** (not Google) as its social provider — so the button + `SOCIAL_PROVIDER` are keyed to GitHub, with a comment noting a clone swaps the button + `SOCIAL_PROVIDER` + the server provider together. The code is kept **textually in sync** with krispy's; divergences (provider name, `@stack/ui` primitives, the `stack-oauth-done` channel) are commented at the seam.

## How it works

1. Click "Continue with GitHub" opens a blank popup **synchronously** inside the gesture.
2. `POST ${NEXT_PUBLIC_API_URL}/api/auth/sign-in/social` (cross-origin, `credentials: "include"`) with `disableRedirect: true` returns the OAuth URL; the popup navigates to it. `callbackURL = ${window.location.origin}/auth/popup-complete` — a web-origin page that Better Auth's `trustedOrigins` already allows.
3. **Completion signal:** the new `/auth/popup-complete` page posts `done` over `BroadcastChannel("stack-oauth-done")` (COOP-safe, unlike `postMessage`/`popup.closed` polling) and calls `window.close()`.
4. The opener's handler calls `getSession()` (refetches + writes the Better Auth session nanostore atom that `useSession` reads) and `router.push("/")` — the gate swaps in the signed-in view **without a full page reload**.
5. **Fallbacks:** popup blocked (mobile) → full-page redirect; the callback page detects no `window.opener` and navigates itself home. No OAuth URL → graceful fallback to `signIn.social(...)` redirect.

No hardcoded hosts — origins from `NEXT_PUBLIC_API_URL` / `window.location.origin`.

## Verification

- `bun run typecheck` (apps/web) — clean.
- `bun run build` (apps/web) — succeeds; `/auth/popup-complete` emitted as a static route.
- **No live deploy:** builders-stack has no deployed preview environment, so verification is typecheck + build only (the runtime flow is verified live on the krispy derivative it's kept in sync with — krispyhq/krispyai-cloud PR #16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)