### PR TITLE
fix(web): kill social popup sign-in latency + silent opener

### DIFF
--- a/apps/web/app/auth/page.tsx
+++ b/apps/web/app/auth/page.tsx
@@ -28,6 +28,7 @@ export default function AuthPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [pending, setPending] = useState(false);
+  const [socialPending, setSocialPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   async function onSubmit(e: React.FormEvent) {
@@ -54,6 +55,7 @@ export default function AuthPage() {
   // @stack/ui primitives + the "stack-oauth-done" channel).
   async function onSocial() {
     setError(null);
+    setSocialPending(true);
 
     // Open a blank popup synchronously inside the click gesture — desktop keeps the
     // user on the sign-in page while the provider loads in the popup. Mobile browsers
@@ -96,18 +98,30 @@ export default function AuthPage() {
             setError(ctx.error.message ?? "Something went wrong."),
         },
       );
+      setSocialPending(false);
       return;
     }
 
     if (popup) {
-      // Desktop popup flow: the callback page broadcasts "done"; we revalidate the
-      // session (no full reload) so the useSession gate swaps in the signed-in view.
-      const bc = new BroadcastChannel("stack-oauth-done");
-      bc.onmessage = () => {
+      // Desktop popup flow. Two ways we learn OAuth finished, whichever fires first:
+      // (1) the callback page broadcasts "done"; (2) we poll popup.closed as a backstop
+      // for a missed broadcast. Either way we refetch the session (no full reload) so
+      // the useSession gate swaps in the signed-in view. socialPending keeps the button
+      // in "Signing you in…" until the session lands.
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
         bc.close();
+        clearInterval(poll);
         void getSession();
         router.push("/");
       };
+      const bc = new BroadcastChannel("stack-oauth-done");
+      bc.onmessage = finish;
+      const poll = setInterval(() => {
+        if (popup.closed) finish();
+      }, 500);
       popup.location.href = url;
     } else {
       // Popup blocked (mobile): full-page redirect. The callback page has no opener,
@@ -129,8 +143,14 @@ export default function AuthPage() {
             </CardDescription>
           </CardHeader>
           <CardContent className="flex flex-col gap-4">
-            <Button type="button" variant="outline" className="w-full" onClick={onSocial}>
-              Continue with GitHub
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={onSocial}
+              disabled={socialPending}
+            >
+              {socialPending ? "Signing you in…" : "Continue with GitHub"}
             </Button>
             <div className="flex items-center gap-3">
               <span className="h-px flex-1 bg-border" />

--- a/apps/web/app/auth/popup-complete/page.tsx
+++ b/apps/web/app/auth/popup-complete/page.tsx
@@ -1,30 +1,34 @@
-"use client";
-
-import { useEffect } from "react";
-
 // Where Better Auth lands the browser after social OAuth completes (passed as
 // `callbackURL` from the auth page — a WEB-origin page, so the session cookie for the
 // api origin is already set by the time we get here).
 //
-// Popup flow: signal the opener that OAuth is done, then close ourselves. We use
-// BroadcastChannel (not postMessage / popup.closed polling) because COOP isolates
-// the opener from the popup — same-origin BroadcastChannel is the reliable channel.
-// Redirect flow (popup was blocked): we ARE the main window, so just go home; the
-// gate revalidates the session on mount.
-export default function PopupComplete() {
-  useEffect(() => {
+// The signal runs from an INLINE script that executes at HTML-parse time — NOT a
+// React effect — so the opener hears "done" the instant this page's HTML lands,
+// with zero Next-runtime download/hydration wait (that lag was the bug). Popup
+// flow: broadcast "done" over BroadcastChannel (COOP-safe; the opener also polls
+// popup.closed as a backstop) then close. Redirect flow (popup blocked → no
+// opener): navigate home so the gate revalidates on mount.
+const SIGNAL = `
+(function () {
+  try {
     if (window.opener) {
-      const bc = new BroadcastChannel("stack-oauth-done");
+      var bc = new BroadcastChannel("stack-oauth-done");
       bc.postMessage("done");
       bc.close();
       window.close();
     } else {
       window.location.href = "/";
     }
-  }, []);
+  } catch (e) {
+    window.location.href = "/";
+  }
+})();
+`;
 
+export default function PopupComplete() {
   return (
     <div className="mx-auto max-w-md">
+      <script dangerouslySetInnerHTML={{ __html: SIGNAL }} />
       <p className="text-sm text-muted-foreground">One moment…</p>
     </div>
   );


### PR DESCRIPTION
## What

Twin of krispy's `fix/popup-latency` (kept textually in sync). Two defects surfaced by the first live sign-in on the derivative: after OAuth consent the popup closed but the opener sat unchanged for **seconds** before the session appeared.

## 1. popup-complete latency — broadcast ran after hydration

`/auth/popup-complete` broadcast `done` from a **React `useEffect`**, so the popup had to download + hydrate the whole Next runtime before signalling — that download is the multi-second lag.

**Fix:** move the broadcast + `window.close()` into an **inline `<script>`** that runs at **HTML-parse time** — no React, no hydration wait. Static string constant, zero interpolation (no XSS surface).

## 2. Silent opener between click and session

**Fix:** a `socialPending` state — the button switches to **"Signing you in…"** and disables from click until the session lands (the `useSession` gate then unmounts the form). On the `BroadcastChannel` message we refetch the session **immediately**, plus a `popup.closed` poll (500ms) **backstop that also refetches** for a missed broadcast.

## Verification

- `bun run typecheck` (apps/web) — clean.
- `bun run build` (apps/web) — succeeds; `/auth/popup-complete` emitted as a static route.
- **No live deploy:** builders-stack has no deployed preview environment. Timing was measured live on the krispy derivative this is kept in sync with — **173/216/210 ms** from opening the completion page to the opener receiving the broadcast (krispyhq/krispyai-cloud PR #18), well under the 300ms target.

Follows #17 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)