### PR TITLE
chore(mcp): pre-wire service MCP servers + hold TypeScript majors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,9 +79,19 @@ BETTERSTACK_SOURCE_TOKEN=                   # Better Stack Logs source token; un
 # BETTERSTACK_INGEST_HOST=https://in.logs.betterstack.com   # override if your source's host differs
 
 # Agent tooling (MCP) — used by agents/mcp.json when copied to .mcp.json.
+# These let your AGENT drive the services (query Neon, manage PostHog flags, read
+# library docs). They are SEPARATE from the app runtime keys above — an app key runs
+# the product; an MCP key runs your agent's control plane. Keep the ${VAR} refs in
+# .mcp.json and put the real values HERE (.env.local is git-ignored).
 # context7 (up-to-date library docs) works KEYLESS at a lower rate limit; add a
 # key to raise it. The postgres MCP reuses DATABASE_URL above (needs `uv` for uvx).
 CONTEXT7_API_KEY=                          # optional — https://context7.com
+# Neon MCP — control plane (projects/branches/queries). Pre-wired READ-ONLY in
+# agents/mcp.json; drop ?readonly=true there to allow branch/migration writes.
+NEON_API_KEY=                              # Neon Console → API Keys
+# PostHog MCP — a PERSONAL API key (phx_…), NOT the phc_ project key above.
+POSTHOG_MCP_API_KEY=                       # PostHog → Settings → Personal API keys
+# Mobbin MCP: browser OAuth on first connect, needs a paid plan (no key here).
 
 # ── Deploy (optional — NOT needed to boot; see docs/deploy.md + docs/secrets.md) ──
 # The code doesn't read these; they live in your CI/deploy environment, not here.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,15 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # TypeScript majors are held back deliberately: TS 7 is the native rewrite and its
+    # changed compiler API breaks Nx's plugins (@nx/eslint + nx/js both throw
+    # "tsModule.readConfigFile is not a function"), failing `nx affected` outright — see
+    # the closed #22. Adopting TS 7 is a real migration gated on Nx support, not an
+    # auto-merge. Minor/patch TS updates still come through. Drop this once Nx ships
+    # TS 7 support.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-dependencies:
         patterns:

--- a/agents/mcp.json
+++ b/agents/mcp.json
@@ -1,27 +1,44 @@
 {
-  "_comment": "Ready-to-use MCP servers for this repo. Copy to `.mcp.json` at the repo root (Claude Code auto-loads it; Cursor/Codex use the same shape). Claude Code expands ${VAR} from your environment — set DATABASE_URL and CONTEXT7_API_KEY in your shell or .env.local. context7 gives your agent up-to-date library docs; postgres (crystaldba/postgres-mcp Pro in read-only `restricted` mode — needs `uv`; replaces the archived, SQL-injectable @modelcontextprotocol/server-postgres) reads the live schema/data via DATABASE_URL; filesystem scopes file access to this repo; mobbin gives your agent 600k+ real app UI screens as design reference (search shipped patterns before building UI) — OAuth on first connect (browser), requires a paid Mobbin plan. See docs/design.md.",
+  "_comment": "Ready-to-use MCP servers for this repo — the agent-side control plane for the services this stack runs on. Copy to `.mcp.json` at the repo root (Claude Code auto-loads it; Cursor/Codex use the same shape). Claude Code expands ${VAR} from your environment, so KEEP THE ${VAR} REFS and put real values in .env.local (git-ignored) — never paste a literal key here, this file is committed. Every key below is documented in .env.example. Servers with an unset key simply fail to connect; the rest still work.",
+  "_replaceThese": "STUBS TO FILL: CONTEXT7_API_KEY (optional, raises rate limit) · DATABASE_URL (already set for local) · NEON_API_KEY · POSTHOG_MCP_API_KEY (a PERSONAL key phx_…, not the phc_ project key). Mobbin uses browser OAuth on first connect and needs a paid plan.",
   "mcpServers": {
     "context7": {
       "type": "stdio",
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"],
-      "_comment": "Key via env, not argv — CLI args show up in `ps`/crash reports. The server reads CONTEXT7_API_KEY when --api-key is absent (same pattern as postgres below).",
+      "_comment": "Up-to-date library docs. Key via env, not argv — CLI args show up in `ps`/crash reports. Works KEYLESS at a lower rate limit. https://context7.com",
       "env": { "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}" }
     },
     "postgres": {
       "type": "stdio",
       "command": "uvx",
       "args": ["postgres-mcp", "--access-mode=restricted"],
+      "_comment": "Reads the live schema/data via DATABASE_URL. crystaldba/postgres-mcp in READ-ONLY `restricted` mode (needs `uv`) — replaces the archived, SQL-injectable @modelcontextprotocol/server-postgres. Pair with the `dba` subagent + agents/skills/optimize-a-query.",
       "env": { "DATABASE_URI": "${DATABASE_URL}" }
+    },
+    "neon": {
+      "type": "http",
+      "url": "https://mcp.neon.tech/mcp?readonly=true",
+      "_comment": "Neon control plane — inspect projects/branches, run queries. READ-ONLY by default (?readonly=true) to match the postgres server above; drop that param to let the agent create branches / run migrations, and only then. Key: Neon Console → API Keys. https://neon.com/docs/ai/neon-mcp-server",
+      "headers": { "Authorization": "Bearer ${NEON_API_KEY}" }
+    },
+    "posthog": {
+      "type": "http",
+      "url": "https://mcp.posthog.com/mcp",
+      "_comment": "Query analytics, manage feature flags, triage errors from the editor. Needs a PERSONAL API key (phx_…) — NOT the phc_ project key the app uses. PostHog → Settings → Personal API keys. Alt install: `npx @posthog/wizard mcp add`.",
+      "headers": { "Authorization": "Bearer ${POSTHOG_MCP_API_KEY}" }
     },
     "filesystem": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "${PWD}"]
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "${PWD}"],
+      "_comment": "Scopes agent file access to this repo."
     },
     "mobbin": {
       "type": "http",
-      "url": "https://api.mobbin.com/mcp"
+      "url": "https://api.mobbin.com/mcp",
+      "_comment": "600k+ real app UI screens as design reference — search shipped patterns before building UI. OAuth on first connect (browser); requires a paid Mobbin plan (free tier returns 401). See docs/design.md."
     }
-  }
+  },
+  "_alsoAvailable": "Other services in this stack ship MCP servers too, deliberately NOT pre-wired here because we could not verify their exact config at authoring time — VET each one before enabling (the 5-step law in docs/stack/agent-skills.md: scan, read the source, check allowed-tools/hooks, check provenance, pin a commit). Cloudflare (Workers/R2/observability): https://developers.cloudflare.com/agents/model-context-protocol/ · Infisical (secrets): https://infisical.com/docs · Resend (email): https://resend.com/docs · Better Stack (logs/uptime): https://betterstack.com/docs. Add them the same way as above — key via env, never argv, least privilege first."
 }


### PR DESCRIPTION
## What
Pre-configures the **agent control plane** for the services this stack runs on, so a cloner sees every supported MCP server with a stub to replace — instead of discovering them one at a time.

### `agents/mcp.json` (the template you copy to `.mcp.json`)
| Server | Controls | Key |
|---|---|---|
| **neon** *(new)* | Neon projects/branches/queries | `NEON_API_KEY` |
| **posthog** *(new)* | analytics, feature flags, error triage | `POSTHOG_MCP_API_KEY` (**personal** `phx_`, not the app's `phc_`) |
| context7 | up-to-date library docs | optional |
| postgres | live schema/data, read-only | reuses `DATABASE_URL` |
| filesystem / mobbin | repo scope / UI reference | — / OAuth |

**Neon is wired READ-ONLY** (`?readonly=true`) to match the restricted postgres server — drop the param to let the agent create branches or run migrations, deliberately.

### Conventions kept
- Keys stay `${VAR}` refs; real values live in `.env.local` (git-ignored as of #25). Nothing secret is committed.
- Keys go via **env, never argv** — CLI args leak through `ps`/crash reports (the pattern #25 introduced).
- Cloudflare / Infisical / Resend / Better Stack are listed as **available but not pre-wired**: their exact config wasn't verifiable at authoring time, and `docs/stack/agent-skills.md` says vet a third-party MCP before baking it into the template.

### `.env.example`
Documents `NEON_API_KEY` + `POSTHOG_MCP_API_KEY`, and draws the line between **app runtime keys** (run the product) and **MCP keys** (run the agent's control plane).

### `.github/dependabot.yml`
Ignores TypeScript **major** bumps. TS 7's rewritten compiler API breaks Nx's plugins — `nx affected` fails outright (`tsModule.readConfigFile is not a function`), see closed #22. Minor/patch TS still flows; drop the ignore once Nx supports TS 7.

## Verify
JSON + YAML parse clean · oxfmt clean · oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)