### PR TITLE
ci(deps): hold oxlint-tsgolint majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,13 @@ updates:
     ignore:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # oxlint-tsgolint is oxlint's type-aware backend; its major line (7.x) tracks
+      # TypeScript 7, which we deliberately hold back (see above). Type-aware mode is
+      # also currently disabled (the backend was OOM-ing at tens of GB). Every regroup
+      # kept re-proposing the 7.x jump (closed #29, #31) — hold its majors too until we
+      # adopt TS 7. Minor/patch still flow.
+      - dependency-name: "oxlint-tsgolint"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-dependencies:
         patterns:


### PR DESCRIPTION
Its 7.x line tracks TypeScript 7 (which we hold back via the existing TS-major ignore) and type-aware mode is disabled anyway (the backend was OOM-ing). Dependabot regroups kept re-proposing the `0.24 → 7.0.2001` jump — closed **#29** and **#31** for it. This ignore lets the safe oxfmt/oxlint minors come through in a clean regroup. Config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)