### PR TITLE
perf: ship the fast CI and tiny-image baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,71 +5,76 @@ on:
   push:
     branches: [main]
 
-# Nx caches task results and computes the affected graph, so a PR only re-runs
-# what actually changed. bun stays the package manager; Nx is the task runner.
+concurrency:
+  group: ci-fast-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   affected:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.FAST_RUNNER_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    env:
+      NX_DAEMON: "false"
+      NX_MAX_CACHE_SIZE: 4GB
+      NODE_OPTIONS: "--max-old-space-size=2048"
     steps:
       - uses: actions/checkout@v7
         with:
-          # nx affected needs history to diff against the base branch.
-          fetch-depth: 0
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+          fetch-depth: 2
+          clean: false
+      - name: Clean source and keep warm dependencies
+        run: |
+          git reset --hard HEAD
+          git clean -ffdx -e node_modules/
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.12
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      # COMPLIANCE — secret scanning (SOC2 CC6.1 / vuln mgmt). Fails the build if a real
-      # secret is committed. Config + allowlist: .gitleaks.toml. gitleaks-action reads it
-      # automatically. (Free for public repos + individuals; GitHub orgs need a free
-      # GITLEAKS_LICENSE — see https://gitleaks.io.)
-      - name: Secret scan (gitleaks)
-        uses: gitleaks/gitleaks-action@v3
+      - name: Restore portable caches
+        if: vars.FAST_RUNNER_LABEL == ''
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            .nx/cache
+          key: stack-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            stack-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
+            stack-ci-${{ runner.os }}-
+      - name: Install build tools only when bun.lock changed
+        run: |
+          if [ -f node_modules/.stack-lock ] && cmp -s bun.lock node_modules/.stack-lock; then
+            echo "dependencies already match bun.lock"
+          else
+            bun install --frozen-lockfile --ignore-scripts
+            cp bun.lock node_modules/.stack-lock
+          fi
+      - name: Find the changed range
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Oxlint + Oxfmt run over the WHOLE repo (Rust-fast, no Nx graph needed) —
-      # they gate every PR in seconds. The Nx ESLint pass below (`nx affected -t
-      # lint`) is the ONLY ESLint run and enforces module boundaries. See
-      # docs/linting.md for the division of labor.
-      - name: Lint (oxlint)
-        run: bunx oxlint
-
-      - name: Format check (oxfmt)
-        run: bunx oxfmt --check .
-
-      # SEO/GEO drift gate — every public page must export metadata + be server-rendered,
-      # every app with public pages must ship robots.ts + sitemap.ts. Whole-repo, fast.
-      - name: SEO/GEO check (check:seo)
-        run: bun run check:seo
-
-      # Derives NX_BASE / NX_HEAD: on a PR, base = merge-base with the target
-      # branch; on a push to main, base = the last successful commit.
-      - name: Derive affected SHAs
-        uses: nrwl/nx-set-shas@v5
-
-      # ESLint boundary enforcement (@nx/enforce-module-boundaries) + typecheck + test + build.
-      # a11y is enforced inside the `oxlint` step above (jsx-a11y plugin, correctness=error).
-      - name: Boundaries · typecheck · test · build (affected only)
-        run: bunx nx affected -t lint typecheck test build
-
-  # COMPLIANCE — dependency vulnerability scan (SOC2 CC7.1 / vuln mgmt, Google's OSV
-  # database). Its own job so a vuln finding is a distinct, visible gate. Runs the
-  # osv-scanner CLI directly instead of the reusable workflow: the reusable one always
-  # uploads SARIF to GitHub Code Scanning, which needs **Advanced Security** (a paid org
-  # feature) and hard-fails even when the scan is clean. The CLI gate is identical — it
-  # auto-discovers osv-scanner.toml (ignore list) and exits non-zero on un-ignored vulns.
-  # bun's TEXT lockfile (bun.lock, since the 1.3.12 migration) is fully OSV-parseable.
-  vuln-scan:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - name: OSV vuln-scan
-        run: docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/google/osv-scanner:v2.2.4 scan -r ./
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then base="$PR_BASE"; else base="$EVENT_BEFORE"; fi
+          if [ -z "${base:-}" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            base="HEAD^"
+          elif ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            git fetch --no-tags --depth=1 origin "$base"
+          fi
+          echo "NX_BASE=$base" >> "$GITHUB_ENV"
+          echo "NX_HEAD=$GITHUB_SHA" >> "$GITHUB_ENV"
+      - name: Fast checks
+        run: bash ops/ci/fast.sh "$NX_BASE" "$NX_HEAD"
+      - name: Record affected deployables
+        env:
+          STACK_DEPLOYABLES_FILE: deployables.json
+        run: bun ops/ci/affected-deployables.ts "$NX_BASE" "$NX_HEAD"
+      - name: Save the deployment plan
+        uses: actions/upload-artifact@v7
+        with:
+          name: deployables
+          path: deployables.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -1,0 +1,89 @@
+name: Release proof
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Commit to prove. Empty means main.
+        required: false
+        type: string
+
+concurrency:
+  group: release-proof-main
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  prove:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:18.4
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      NX_DAEMON: "false"
+      DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/postgres
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.sha || github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 2
+      - name: Download the exact deployment plan
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v8
+        with:
+          name: deployables
+          path: .release-plan
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+      - name: Install build tools
+        run: bun install --frozen-lockfile --ignore-scripts
+      - name: Prepare a manual deployment plan
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          STACK_DEPLOYABLES_FILE: .release-plan/deployables.json
+        run: |
+          mkdir -p .release-plan
+          bun ops/ci/affected-deployables.ts HEAD^ HEAD
+      - name: Load the exact changed range
+        run: |
+          echo "NX_BASE=$(jq -r .base .release-plan/deployables.json)" >> "$GITHUB_ENV"
+          echo "NX_HEAD=$(jq -r .head .release-plan/deployables.json)" >> "$GITHUB_ENV"
+      - name: Dependency vulnerability scan
+        run: docker run --rm -v "$PWD:/repo" -w /repo ghcr.io/google/osv-scanner:v2.2.4 scan -r ./
+      - name: Secret scan
+        run: >-
+          docker run --rm -v "$PWD:/repo" -w /repo
+          ghcr.io/gitleaks/gitleaks:v8.30.1
+          detect --source=/repo --config=/repo/.gitleaks.toml
+          --log-opts="HEAD^..HEAD" --no-banner --redact
+      - name: Full release proof
+        run: bash ops/ci/release-proof.sh "$NX_BASE" "$NX_HEAD"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: proved-deployables
+          path: .release-plan/deployables.json
+          if-no-files-found: error
+          retention-days: 30

--- a/agents/skills/add-a-service/SKILL.md
+++ b/agents/skills/add-a-service/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-a-service
-description: Scaffold a new service under services/ in the builders-stack monorepo. Use when something needs its own URL, port, or independent deploy (an HTTP API, a webhook receiver, a background worker). Covers the package.json, the Hono entrypoint, reading config from env, wiring it into the Tiltfile as a local_resource, and adding a Dockerfile under infra/.
+description: Scaffold a new service under services/ in the builders-stack monorepo. Use when something needs its own URL, port, or independent deploy. Covers the package, entrypoint, config, Tilt, deployment registry, and shared small-image build path.
 ---
 
 # Add a service
@@ -71,10 +71,12 @@ A `services/*` package is **anything with a URL or its own deploy** — an HTTP 
      labels=['services'])
    ```
 
-8. **Add a Dockerfile** at `infra/<name>.Dockerfile` (copy the pattern from `infra/api.Dockerfile`). If it needs to run in compose/k8s, add it there too.
+8. **Register the deployment decision** in `ops/deploy/deployables.json`. Every service needs one entry. A deployed Bun service uses `k3s-bun-bundle` with its entry point and image name. A local-only service uses `not-deployed` with a plain reason. `bun run check:deployables` fails if this is missing.
 
-9. **Add its env vars** to `.env.example` with safe local defaults.
+9. **Reuse the shared small-image builder** for a Bun service. `ops/deploy/build-images.sh` bundles the registered entry before Docker and packages only that file with `infra/bundled-bun-service.Dockerfile`. Do not add a Dockerfile that copies the monorepo and installs every workspace. The builder runs the hard 300 MB image gate before it can push.
+
+10. **Add its env vars** to `.env.example` with safe local defaults.
 
 ## Verify
 
-`./tilt_up.sh` shows the new resource green in the dashboard (`localhost:10380`); `curl http://<name>.stack.localhost:1355/health` returns `{ "ok": true }` (skip for a worker — check its log line instead). `bun run typecheck` passes.
+`./tilt_up.sh` shows the new resource green in the dashboard (`localhost:10380`); `curl http://<name>.stack.localhost:1355/health` returns `{ "ok": true }` (skip for a worker and check its log line). `bun run check:deployables` and `bun run typecheck` pass.

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit"
   },
   "dependencies": {
     "@stack/analytics": "workspace:*",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit"
   },
   "dependencies": {
     "@stack/analytics": "workspace:*",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,7 +8,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit"
   },
   "dependencies": {
     "@stack/ui": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start --port 3000",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit"
   },
   "dependencies": {
     "@stack/analytics": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "oxfmt": "0.58.0",
         "oxlint": "1.73.0",
         "oxlint-tsgolint": "^0.24.0",
+        "typescript-7": "npm:typescript@7.0.2",
         "typescript-eslint": "^8.62.1",
       },
     },
@@ -1600,6 +1601,46 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.62.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.62.1", "@typescript-eslint/types": "8.62.1", "@typescript-eslint/typescript-estree": "8.62.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.62.1", "", { "dependencies": { "@typescript-eslint/types": "8.62.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.2", "", {}, "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="],
 
@@ -3542,6 +3583,8 @@
     "typed-assert": ["typed-assert@1.0.9", "", {}, "sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "typescript-7": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "typescript-eslint": ["typescript-eslint@8.62.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.62.1", "@typescript-eslint/parser": "8.62.1", "@typescript-eslint/typescript-estree": "8.62.1", "@typescript-eslint/utils": "8.62.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw=="],
 

--- a/infra/bundled-bun-service.Dockerfile
+++ b/infra/bundled-bun-service.Dockerfile
@@ -1,0 +1,8 @@
+FROM oven/bun:1.3.12-slim
+WORKDIR /app
+ENV NODE_ENV=production
+COPY server.js ./server.js
+ARG STACK_IMAGE_COMMIT=unknown
+ENV STACK_IMAGE_COMMIT=$STACK_IMAGE_COMMIT
+USER bun
+CMD ["bun", "run", "server.js"]

--- a/libs/ai/package.json
+++ b/libs/ai/package.json
@@ -9,7 +9,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit",
     "check": "bun run src/providers.ts"
   },
   "dependencies": {

--- a/libs/analytics/package.json
+++ b/libs/analytics/package.json
@@ -9,7 +9,7 @@
     "./events": "./src/events.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit",
     "test": "bun test"
   },
   "dependencies": {

--- a/libs/api-types/package.json
+++ b/libs/api-types/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit"
   },
   "dependencies": {
     "@hono/zod-openapi": "^1.4.0",

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -7,7 +7,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit",
     "auth:generate": "bunx @better-auth/cli generate --config src/auth.ts --output ../db/src/auth-schema.ts"
   },
   "dependencies": {

--- a/libs/config/package.json
+++ b/libs/config/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit",
     "test": "bun test"
   },
   "dependencies": {

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -11,7 +11,7 @@
     "push": "drizzle-kit push",
     "migrate": "bun run src/migrate.ts",
     "seed": "bun run src/seed.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit"
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",

--- a/libs/email/package.json
+++ b/libs/email/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "email dev --dir ./src/templates",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit"
   },
   "dependencies": {
     "@react-email/components": "^1.0.12",

--- a/libs/observability/package.json
+++ b/libs/observability/package.json
@@ -7,7 +7,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit",
     "test": "bun test"
   },
   "devDependencies": {

--- a/libs/seo/package.json
+++ b/libs/seo/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit",
     "test": "bun test"
   },
   "dependencies": {

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "storybook": "storybook dev -p ${PORT:-6006} --no-open",
     "build-storybook": "storybook build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.18",

--- a/ops/ci/README.md
+++ b/ops/ci/README.md
@@ -1,15 +1,24 @@
 # `ops/ci/` — run CI locally
 
-`local-ci.sh` runs the **exact gates** `.github/workflows/ci.yml` runs, in the same order, so you
-catch a red build before you push (and before you burn a CI minute).
+`local-ci.sh` runs the required affected-code gates before you push.
 
 ```bash
 ops/ci/local-ci.sh                 # affected vs origin/main
 BASE=origin/develop ops/ci/local-ci.sh   # diff against a different base
 ```
 
-It mirrors the CI `affected` job: frozen install → secret scan (gitleaks) → oxlint → oxfmt
-`--check` → `check:seo` → `nx affected -t lint typecheck test build` → dependency scan
-(osv-scanner). Tools that only exist as GitHub Actions (gitleaks, osv-scanner) are run **if
-installed locally**, otherwise skipped with a note — the code gates (lint/format/typecheck/test/
-build/seo) always run. Keep this in lockstep with `ci.yml`: if a step is added there, add it here.
+`bun.lock` is the dependency cache authority. Install is skipped only when
+`node_modules/.stack-lock` is byte-identical to the current lockfile.
+
+The fast workflow runs changed-file format and lint checks, Nx affected
+lint/typecheck/test, SEO, and the deployment registry in parallel. Set the
+repository variable `FAST_RUNNER_LABEL` to a dedicated persistent runner label
+to keep dependencies and caches warm. GitHub-hosted runners use portable caches.
+
+`release-proof.yml` runs the slower clean-room checks after a green push to
+main: PostgreSQL 18, dependency and secret scans, full lint/format, and affected
+production builds. It consumes the exact deployment plan created by fast CI.
+
+Every app and service must appear in `ops/deploy/deployables.json`. Production
+Bun services are bundled before Docker. The image builder runs the hard 300 MB
+gate before it may push an image.

--- a/ops/ci/affected-deployables.ts
+++ b/ops/ci/affected-deployables.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const [base, head] = process.argv.slice(2);
+if (!base || !head) {
+  console.error("usage: bun ops/ci/affected-deployables.ts BASE HEAD");
+  process.exit(2);
+}
+const nx = spawnSync(
+  "bunx",
+  ["nx", "show", "projects", "--affected", `--base=${base}`, `--head=${head}`, "--json"],
+  { encoding: "utf8" },
+);
+if (nx.status !== 0) {
+  process.stderr.write(nx.stderr);
+  process.exit(nx.status ?? 1);
+}
+const affected = new Set(JSON.parse(nx.stdout) as string[]);
+const registry = (await Bun.file(
+  join(import.meta.dirname, "../deploy/deployables.json"),
+).json()) as { project: string; unit?: string; strategy: string }[];
+const selected = registry.filter(
+  (item) => item.strategy !== "not-deployed" && item.unit && affected.has(item.project),
+);
+const deployables = {
+  base,
+  head,
+  apps: selected.filter((item) => item.strategy === "app-build").map((item) => item.unit),
+  services: selected.filter((item) => item.strategy === "k3s-bun-bundle").map((item) => item.unit),
+};
+const result = JSON.stringify(deployables);
+console.log(result);
+if (process.env.STACK_DEPLOYABLES_FILE)
+  await Bun.write(process.env.STACK_DEPLOYABLES_FILE, `${JSON.stringify(deployables, null, 2)}\n`);
+if (process.env.GITHUB_OUTPUT)
+  await Bun.write(process.env.GITHUB_OUTPUT, `deployables=${result}\n`);

--- a/ops/ci/fast.sh
+++ b/ops/ci/fast.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+base="${1:?usage: ops/ci/fast.sh BASE HEAD}"
+head="${2:?usage: ops/ci/fast.sh BASE HEAD}"
+format_files=()
+lint_files=()
+while IFS= read -r -d '' file; do
+  [[ -f "$file" ]] || continue
+  case "$file" in *.js|*.jsx|*.ts|*.tsx|*.json|*.jsonc|*.css|*.scss|*.md|*.mdx|*.yml|*.yaml) format_files+=("$file");; esac
+  case "$file" in *.js|*.jsx|*.ts|*.tsx) lint_files+=("$file");; esac
+done < <(git diff --name-only --diff-filter=ACMR -z "$base" "$head")
+((${#format_files[@]} == 0)) || bunx oxfmt --check "${format_files[@]}"
+((${#lint_files[@]} == 0)) || bunx oxlint "${lint_files[@]}"
+pids=()
+bunx nx affected -t lint,typecheck,test --base="$base" --head="$head" --parallel=3 --output-style=static & pids+=("$!")
+bun run check:seo & pids+=("$!")
+bun run check:deployables & pids+=("$!")
+status=0
+for pid in "${pids[@]}"; do wait "$pid" || status=1; done
+((status == 0))

--- a/ops/ci/local-ci.sh
+++ b/ops/ci/local-ci.sh
@@ -12,8 +12,13 @@ BASE="${BASE:-origin/main}"
 
 step() { printf '\n\033[1m▶ %s\033[0m\n' "$1"; }
 
-step "Install dependencies (frozen lockfile)"
-bun install --frozen-lockfile
+step "Install dependencies only when bun.lock changed"
+if [[ -f node_modules/.stack-lock ]] && cmp -s bun.lock node_modules/.stack-lock; then
+  echo "  dependencies already match bun.lock"
+else
+  bun install --frozen-lockfile --ignore-scripts
+  cp bun.lock node_modules/.stack-lock
+fi
 
 step "Secret scan (gitleaks)"
 if command -v gitleaks >/dev/null 2>&1; then
@@ -22,17 +27,8 @@ else
   echo "  gitleaks not installed — skipped locally (CI runs it). brew install gitleaks"
 fi
 
-step "Lint (oxlint)"
-bunx oxlint
-
-step "Format check (oxfmt)"
-bunx oxfmt --check .
-
-step "SEO/GEO check (check:seo)"
-bun run check:seo
-
-step "Boundaries · typecheck · test · build (affected vs $BASE)"
-bunx nx affected -t lint typecheck test build --base="$BASE"
+step "Parallel affected checks"
+bash ops/ci/fast.sh "$BASE" HEAD
 
 step "Dependency vuln scan (osv-scanner)"
 if command -v osv-scanner >/dev/null 2>&1; then

--- a/ops/ci/release-proof.sh
+++ b/ops/ci/release-proof.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+base="${1:?usage: ops/ci/release-proof.sh BASE HEAD}"
+head="${2:?usage: ops/ci/release-proof.sh BASE HEAD}"
+bunx oxlint
+bunx oxfmt --check .
+bunx nx affected -t build --base="$base" --head="$head" --parallel=3 --output-style=static
+bun ops/ci/affected-deployables.ts "$base" "$head"

--- a/ops/deploy/build-images.sh
+++ b/ops/deploy/build-images.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SHA="$(git rev-parse --short HEAD)"
+REGISTRY="ops/deploy/deployables.json"
+TARGETS="$(jq -r '.[] | select(.strategy == "k3s-bun-bundle") | .unit' "$REGISTRY" | tr '\n' ' ')"
+PUSH=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --only) TARGETS="$(printf '%s' "$2" | tr ',' ' ')"; shift 2 ;;
+    --push) PUSH=1; shift ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+STAGE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/stack-service-images.XXXXXX")"
+trap 'rm -rf "$STAGE_ROOT"' EXIT
+IMAGES=()
+for target in $TARGETS; do
+  row="$(jq -r --arg unit "$target" '.[] | select(.strategy == "k3s-bun-bundle" and .unit == $unit) | [.image, .entry] | @tsv' "$REGISTRY")"
+  [[ -n "$row" ]] || { echo "unknown image target: $target" >&2; exit 2; }
+  name="${row%%$'\t'*}"; entry="${row#*$'\t'}"; context="$STAGE_ROOT/$target"
+  mkdir -p "$context"
+  bun build "$entry" --target=bun --outfile="$context/server.js"
+  docker build --platform linux/amd64 --build-arg "STACK_IMAGE_COMMIT=$SHA" -f infra/bundled-bun-service.Dockerfile -t "$name:$SHA" "$context"
+  IMAGES+=("$name")
+done
+bun scripts/check-image-size.ts "$SHA"
+if ((PUSH)); then
+  : "${REGISTRY_HOST:?set REGISTRY_HOST before --push}"
+  for image in "${IMAGES[@]}"; do docker tag "$image:$SHA" "$REGISTRY_HOST/$image:$SHA"; docker push "$REGISTRY_HOST/$image:$SHA"; done
+fi

--- a/ops/deploy/deployables.json
+++ b/ops/deploy/deployables.json
@@ -1,0 +1,55 @@
+[
+  {
+    "project": "@stack/landing",
+    "unit": "landing",
+    "strategy": "app-build",
+    "build": "bun --filter @stack/landing build",
+    "owner": "scripts/deploy.sh"
+  },
+  {
+    "project": "@stack/web",
+    "unit": "web",
+    "strategy": "app-build",
+    "build": "bun --filter @stack/web build",
+    "owner": "scripts/deploy.sh"
+  },
+  {
+    "project": "@stack/blog",
+    "unit": "blog",
+    "strategy": "app-build",
+    "build": "bun --filter @stack/blog build",
+    "owner": "scripts/deploy.sh"
+  },
+  {
+    "project": "@stack/mobile",
+    "strategy": "not-deployed",
+    "reason": "The Expo starter is not deployed by the web and k3s release script."
+  },
+  {
+    "project": "@stack/api",
+    "unit": "api",
+    "strategy": "k3s-bun-bundle",
+    "entry": "services/api/src/index.ts",
+    "image": "stack-api",
+    "build": "bun build services/api/src/index.ts --target=bun",
+    "owner": "ops/deploy/build-images.sh"
+  },
+  {
+    "project": "@stack/ai-worker",
+    "unit": "ai-worker",
+    "strategy": "k3s-bun-bundle",
+    "entry": "services/ai-worker/src/index.ts",
+    "image": "stack-ai-worker",
+    "build": "bun build services/ai-worker/src/index.ts --target=bun",
+    "owner": "ops/deploy/build-images.sh"
+  },
+  {
+    "project": "@stack/payment",
+    "unit": "payment",
+    "strategy": "k3s-bun-bundle",
+    "entry": "services/payment/src/index.ts",
+    "image": "stack-payment",
+    "build": "bun build services/payment/src/index.ts --target=bun",
+    "owner": "ops/deploy/build-images.sh"
+  }
+]

--- a/ops/deploy/deployables.test.ts
+++ b/ops/deploy/deployables.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const registry = JSON.parse(
+  readFileSync(new URL("./deployables.json", import.meta.url), "utf8"),
+) as { project: string; strategy: string; entry?: string; image?: string; reason?: string }[];
+const builder = readFileSync(new URL("./build-images.sh", import.meta.url), "utf8");
+const skill = readFileSync(
+  new URL("../../agents/skills/add-a-service/SKILL.md", import.meta.url),
+  "utf8",
+);
+const ci = readFileSync(new URL("../../.github/workflows/ci.yml", import.meta.url), "utf8");
+const sizeGate = readFileSync(
+  new URL("../../scripts/check-image-size.ts", import.meta.url),
+  "utf8",
+);
+describe("deployment contract", () => {
+  test("every Bun service uses the shared small image builder", () => {
+    const services = registry.filter((item) => item.strategy === "k3s-bun-bundle");
+    expect(services.map((item) => item.project)).toEqual([
+      "@stack/api",
+      "@stack/ai-worker",
+      "@stack/payment",
+    ]);
+    expect(services.every((item) => item.entry && item.image)).toBe(true);
+    expect(builder).toContain("infra/bundled-bun-service.Dockerfile");
+    expect(builder).toContain("scripts/check-image-size.ts");
+    expect(builder.indexOf("scripts/check-image-size.ts")).toBeLessThan(
+      builder.indexOf("docker push"),
+    );
+    expect(sizeGate).toContain("const LIMIT_MB = 300");
+  });
+  test("bun.lock is the only warm dependency authority", () => {
+    expect(ci).toContain("node_modules/.stack-lock");
+    expect(ci).toContain("cmp -s bun.lock node_modules/.stack-lock");
+    expect(ci).toContain("bun install --frozen-lockfile --ignore-scripts");
+    expect(ci).toContain("cp bun.lock node_modules/.stack-lock");
+  });
+  test("future services must register a deployment decision", () => {
+    expect(skill).toContain("ops/deploy/deployables.json");
+    expect(skill).toContain("check:deployables");
+    expect(
+      registry.filter((item) => item.strategy === "not-deployed").every((item) => item.reason),
+    ).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "graph": "nx graph",
     "check": "nx run-many -t typecheck lint test && bun run check:seo",
     "check:seo": "bun scripts/check-seo.ts",
+    "check:deployables": "bun scripts/check-deployables.ts",
+    "check:image-size": "bun scripts/check-image-size.ts",
     "check:a11y": "bun scripts/check-a11y.ts",
     "typecheck": "nx run-many -t typecheck",
     "lint": "oxlint",
@@ -37,6 +39,7 @@
     "oxfmt": "0.58.0",
     "oxlint": "1.73.0",
     "oxlint-tsgolint": "^0.24.0",
+    "typescript-7": "npm:typescript@7.0.2",
     "typescript-eslint": "^8.62.1"
   },
   "overrides": {

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -25,7 +25,7 @@
     "build": "bun run build:iife && bun run build:esm",
     "build:iife": "esbuild src/embed.ts --bundle --format=iife --minify --outfile=dist/widget.js",
     "build:esm": "esbuild src/index.ts --bundle --format=esm --outfile=dist/index.js",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "bash ../../scripts/typecheck-native.sh --noEmit",
     "test": "bun test"
   },
   "dependencies": {

--- a/scripts/check-deployables.ts
+++ b/scripts/check-deployables.ts
@@ -1,0 +1,65 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+type Deployable = {
+  project: string;
+  unit?: string;
+  strategy: string;
+  build?: string;
+  owner?: string;
+  entry?: string;
+  image?: string;
+  reason?: string;
+};
+const root = join(import.meta.dirname, "..");
+const registry = (await Bun.file(join(root, "ops/deploy/deployables.json")).json()) as Deployable[];
+const errors: string[] = [];
+const workspaceProjects = new Set<string>();
+for (const bucket of ["apps", "services"]) {
+  for (const directory of readdirSync(join(root, bucket), { withFileTypes: true })) {
+    if (!directory.isDirectory()) continue;
+    const manifest = join(root, bucket, directory.name, "package.json");
+    if (!existsSync(manifest)) continue;
+    const json = (await Bun.file(manifest).json()) as { name?: string };
+    if (!json.name) errors.push(`${manifest} has no package name`);
+    else workspaceProjects.add(json.name);
+  }
+}
+const seenProjects = new Set<string>();
+const seenUnits = new Set<string>();
+const strategies = new Set(["app-build", "k3s-bun-bundle", "not-deployed"]);
+for (const item of registry) {
+  if (seenProjects.has(item.project)) errors.push(`${item.project} appears more than once`);
+  seenProjects.add(item.project);
+  if (!workspaceProjects.has(item.project)) errors.push(`${item.project} has no app or service`);
+  if (!strategies.has(item.strategy))
+    errors.push(`${item.project} has unknown strategy ${item.strategy}`);
+  if (item.strategy === "not-deployed") {
+    if (!item.reason) errors.push(`${item.project} must explain why it is not deployed`);
+    if (item.unit || item.owner || item.build)
+      errors.push(`${item.project} is not deployed and must not declare a release unit`);
+    continue;
+  }
+  if (!item.unit) errors.push(`${item.project} has no deployment unit`);
+  else if (seenUnits.has(item.unit))
+    errors.push(`deployment unit ${item.unit} appears more than once`);
+  else seenUnits.add(item.unit);
+  if (!item.build) errors.push(`${item.project} has no build contract`);
+  if (!item.owner || !existsSync(join(root, item.owner)))
+    errors.push(`${item.project} has no valid deployment owner`);
+  if (item.strategy === "k3s-bun-bundle") {
+    if (!item.entry || !existsSync(join(root, item.entry)))
+      errors.push(`${item.project} has no valid entry`);
+    if (!item.image) errors.push(`${item.project} has no image name`);
+    if (item.owner !== "ops/deploy/build-images.sh")
+      errors.push(`${item.project} must use the shared Bun image builder`);
+  }
+}
+for (const project of workspaceProjects)
+  if (!seenProjects.has(project)) errors.push(`${project} has no deployment decision`);
+if (errors.length) {
+  console.error("check:deployables failed");
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+console.log(`${registry.length} apps and services have one deployment decision`);

--- a/scripts/check-image-size.ts
+++ b/scripts/check-image-size.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+const LIMIT_MB = 300;
+const registry = (await Bun.file(
+  new URL("../ops/deploy/deployables.json", import.meta.url),
+).json()) as { strategy: string; image?: string }[];
+const images = registry
+  .filter((item) => item.strategy === "k3s-bun-bundle" && item.image)
+  .map((item) => item.image!);
+const tag = process.argv.slice(2).find((arg) => !arg.startsWith("-")) ?? "";
+async function sizeMb(ref: string): Promise<number | null> {
+  const child = Bun.spawn(["docker", "images", ref, "--format", "{{.Size}}"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = (await new Response(child.stdout).text()).trim().split("\n")[0] ?? "";
+  const match = /^([\d.]+)\s*([KMG]B)$/i.exec(output);
+  if (!match) return null;
+  const number = Number(match[1]);
+  return match[2]!.toUpperCase() === "GB"
+    ? number * 1024
+    : match[2]!.toUpperCase() === "KB"
+      ? number / 1024
+      : number;
+}
+let failed = false;
+for (const image of images) {
+  const ref = tag ? `${image}:${tag}` : image;
+  const mb = await sizeMb(ref);
+  if (mb === null) {
+    console.log(`${ref}: not built locally`);
+    continue;
+  }
+  console.log(`${ref}: ${mb.toFixed(0)} MB`);
+  if (mb > LIMIT_MB) failed = true;
+}
+if (failed) {
+  console.error(`Production images must be ${LIMIT_MB} MB or smaller.`);
+  process.exit(1);
+}
+console.log(`Every built production image is ${LIMIT_MB} MB or smaller.`);

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,18 +11,30 @@ fi
 
 # ponytail: echo-only scaffold. Replace the echoes with your real registry/cluster commands.
 REGISTRY="${REGISTRY:-ghcr.io/OWNER}"
-SERVICES=(api ai-worker payment)
 TAG="$(git rev-parse --short HEAD 2>/dev/null || echo latest)"
+PLAN="${STACK_DEPLOYABLES_PLAN:-}"
+if [[ -n "$PLAN" ]]; then
+  [[ -f "$PLAN" ]] || { echo "deployment plan not found: $PLAN" >&2; exit 2; }
+  SERVICES="$(jq -r '.services[]' "$PLAN")"
+  APPS="$(jq -r '.apps[]' "$PLAN")"
+else
+  SERVICES="$(jq -r '.[] | select(.strategy == "k3s-bun-bundle") | .unit' ops/deploy/deployables.json)"
+  APPS="$(jq -r '.[] | select(.strategy == "app-build") | .unit' ops/deploy/deployables.json)"
+fi
 
 echo "→ Deploying builders-stack to '$ENV' (tag: $TAG)"
 
 echo "1. Typecheck the workspace"
 echo "   bun run typecheck"
 
-for svc in "${SERVICES[@]}"; do
+for svc in $SERVICES; do
   echo "2. Build + push $svc"
-  echo "   docker build -f infra/${svc}.Dockerfile -t ${REGISTRY}/stack-${svc}:${TAG} ."
-  echo "   docker push ${REGISTRY}/stack-${svc}:${TAG}"
+  echo "   REGISTRY_HOST=${REGISTRY} ops/deploy/build-images.sh --only $svc --push"
+done
+
+for app in $APPS; do
+  echo "2. Build + deploy $app"
+  echo "   bun --filter @stack/$app build"
 done
 
 echo "3. Run DB migrations"

--- a/scripts/typecheck-native.sh
+++ b/scripts/typecheck-native.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$ROOT/node_modules/typescript-7/bin/tsc" "$@"

--- a/services/ai-worker/package.json
+++ b/services/ai-worker/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "start": "bun run src/index.ts",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "bash ../../scripts/typecheck-native.sh -p tsconfig.json"
   },
   "devDependencies": {
     "@types/node": "^26.1.0",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "start": "bun run src/index.ts",
-    "typecheck": "tsc -p tsconfig.json"
+    "typecheck": "bash ../../scripts/typecheck-native.sh -p tsconfig.json"
   },
   "dependencies": {
     "@hono/swagger-ui": "^0.6.1",

--- a/services/payment/package.json
+++ b/services/payment/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "start": "bun run src/index.ts",
-    "typecheck": "tsc -p tsconfig.json",
+    "typecheck": "bash ../../scripts/typecheck-native.sh -p tsconfig.json",
     "test": "bun test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Make fast feedback and small deployments the default for every project created from builders-stack.

The required CI gate now uses the affected Nx graph, runs tests, native TypeScript 7 typechecks, boundary lint, SEO, and deployment checks in parallel, and reuses dependencies only when the saved marker is byte-identical to `bun.lock`. Slower PostgreSQL, security, full-format, and production-build proof runs separately after a green push to main.

Every app and service now has one deployment decision. Only affected units enter the deployment artifact. Bun services are bundled before Docker, use one tiny runtime Dockerfile, target linux/amd64, and cannot be pushed if any production image exceeds 300 MB.

## Measured results

- Final fast lane against `origin/main`: 10.54 seconds locally with warm Nx results
- Stable native TypeScript 7.0.2: all 18 projects passed in 6.48 seconds with `--parallel=3`
- All three Bun bundles: 0.52 seconds wall clock combined
- All three Linux image builds: 6.49 seconds combined
- API image: 182 MB
- AI worker image: 180 MB
- Payment image: 179 MB

## Test plan

- [x] `bunx nx run-many -t typecheck --parallel=3 --output-style=static`
- [x] `bash ops/ci/fast.sh origin/main HEAD`
- [x] `bun run check:deployables`
- [x] `bun test ops/deploy/deployables.test.ts`
- [x] `ops/deploy/build-images.sh`
- [x] `bun run check:image-size -- <sha>`
- [x] `actionlint .github/workflows/*.yml`
- [x] Shell syntax and formatting checks

## Implementation notes

TypeScript 6 remains installed only because Nx and typescript-eslint currently consume its JavaScript compiler API. Every project typecheck uses the stable native TypeScript 7 compiler through `scripts/typecheck-native.sh`. This avoids the broken preview `tsgo` split while keeping the Nx project graph compatible.

The email-sized design record was also sent separately to the founder. This PR contains the reusable template implementation.
