### PR TITLE
fix(ci): ignore release artifacts in source formatting

### DIFF
--- a/ops/ci/release-proof.sh
+++ b/ops/ci/release-proof.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 base="${1:?usage: ops/ci/release-proof.sh BASE HEAD}"
 head="${2:?usage: ops/ci/release-proof.sh BASE HEAD}"
 bunx oxlint
-bunx oxfmt --check .
+# The workflow downloads its deployment receipt into .release-plan. Check only
+# repository source so an artifact cannot become a false formatting failure.
+git ls-files -z | xargs -0 bunx oxfmt --check
 bunx eslint apps services libs packages
 bun run check:typescript
 bunx nx affected -t build --base="$base" --head="$head" --parallel=3 --output-style=static


### PR DESCRIPTION
## Summary

The release-proof workflow downloads a generated deployment receipt into `.release-plan`, then ran repository formatting over the whole working directory. That made a generated artifact fail a source-code gate after the main commit had already passed.

Format only Git-tracked source files. The generated deployment plan remains validated by its own typed producer and is no longer mistaken for source.

## Test plan

- [x] Create an intentionally unformatted `.release-plan/deployables.json`
- [x] `git ls-files -z | xargs -0 bunx oxfmt --check`
- [x] `git diff --check`