### PR TITLE
perf(ci): skip slower portable caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.12
-      - name: Restore portable caches
-        if: vars.FAST_RUNNER_LABEL == ''
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.bun/install/cache
-            .nx/cache
-          key: stack-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ github.sha }}
-          restore-keys: |
-            stack-ci-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
-            stack-ci-${{ runner.os }}-
       - name: Install build tools only when bun.lock changed
         run: |
           if [ -f node_modules/.stack-lock ] && cmp -s bun.lock node_modules/.stack-lock; then

--- a/ops/ci/README.md
+++ b/ops/ci/README.md
@@ -11,9 +11,11 @@ BASE=origin/develop ops/ci/local-ci.sh   # diff against a different base
 `node_modules/.stack-lock` is byte-identical to the current lockfile.
 
 The fast workflow runs changed-file format and lint checks, Nx affected
-lint/typecheck/test, SEO, and the deployment registry in parallel. Set the
+typecheck/test, SEO, and the deployment registry in parallel. A persistent runner
+keeps `node_modules` behind the exact `bun.lock` marker. Ephemeral GitHub runners install
+cold because restoring and saving a portable cache takes longer than Bun's install. Set the
 repository variable `FAST_RUNNER_LABEL` to a dedicated persistent runner label
-to keep dependencies and caches warm. GitHub-hosted runners use portable caches.
+to keep dependencies warm.
 
 `release-proof.yml` runs the slower clean-room checks after a green push to
 main: PostgreSQL 18, dependency and secret scans, full lint/format, and affected


### PR DESCRIPTION
## Summary

The GitHub-hosted main run spent longer restoring and uploading portable Bun/Nx caches than Bun needs for a cold install. Remove that counterproductive cache path.

Persistent self-hosted runners still keep `node_modules` and reuse it only when the saved marker is byte-identical to `bun.lock`. Ephemeral GitHub runners now install cold and avoid the expensive cache post-step.

## Measured reason

- Prior main run: 55 seconds
- Cache-heavy follow-up: 67 seconds
- Actual parallel checks remained fast; cache restore/upload was the added delay

## Test plan

- [x] `bun test ops/deploy/deployables.test.ts`
- [x] `bunx oxfmt --check .github/workflows/ci.yml ops/ci/README.md`
- [x] `git diff --check`