### PR TITLE
Adopt the Worktree Zero lifecycle

### DIFF
--- a/.agents/skills/create-a-worktree
+++ b/.agents/skills/create-a-worktree
@@ -1,0 +1,1 @@
+../../agents/skills/create-a-worktree

--- a/.claude/skills/create-a-worktree
+++ b/.claude/skills/create-a-worktree
@@ -1,0 +1,1 @@
+../../agents/skills/create-a-worktree

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ Parallel work must use `ops/dev/worktree.sh <branch>`. Do not run raw
 global virtual store, so immutable packages are installed once and each
 worktree gets its own small tree of links. A whole-directory symlink is unsafe
 when branches change dependencies or an install mutates the directory.
+The wrapper delegates source checkout, physical copy-on-write, runtime
+inspection, removal, and pruning to [Worktree Zero](https://github.com/lonormaly/worktree-zero).
+Install the `wt0` binary before starting parallel work; do not substitute a
+second local worktree implementation.
 
 Every agent that creates a worktree owns its cleanup:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ This is a bun-workspace monorepo. Read this before writing code; it tells you wh
   file-touching agent. Never run raw `git worktree add`, copy `node_modules`, or
   symlink a complete `node_modules` from another checkout. The wrapper requires
   Bun 1.3.14 and uses the isolated global virtual store, so packages are shared
-  safely without sharing a mutable dependency directory. After the PR merges or
+  safely without sharing a mutable dependency directory. Source checkout and
+  teardown are provided by the single `wt0` binary from Worktree Zero. After the PR merges or
   the task is abandoned, leave the checkout and run
   `ops/dev/worktree.sh --rm <branch>` from main. Run `--gc` for finished
   worktrees. Never bypass its eight-worktree cap or force removal: dirty,

--- a/agents/skills/create-a-worktree/SKILL.md
+++ b/agents/skills/create-a-worktree/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: create-a-worktree
+description: Create, inspect, or retire an isolated Builders Stack agent runtime through Worktree Zero. Use whenever parallel work needs another checkout or an old worktree needs cleanup.
+---
+
+# Create a Builders Stack worktree
+
+Use the repository adapter. It keeps project policy in Builders Stack while the
+generic source and runtime lifecycle comes from the single `wt0` binary.
+
+## Create
+
+1. Preserve every existing change in the current checkout.
+2. Confirm `wt0 --help` and Bun 1.3.14 are available.
+3. From the main checkout, run:
+
+```bash
+ops/dev/worktree.sh <namespaced-branch>
+```
+
+Use the absolute path it prints. Do not call raw `git worktree`, copy the repo,
+copy `node_modules`, or share a complete mutable dependency directory.
+
+## Work and inspect
+
+- Start the stack only through the checkout's normal project command.
+- Use `wt0 doctor <path>` when storage or dependency sharing is in doubt.
+- Keep the returned branch and path as the runtime identity for later cleanup.
+
+## Remove
+
+After the patch is present in `origin/main`, leave the checkout and run:
+
+```bash
+ops/dev/worktree.sh --rm <branch>
+```
+
+The adapter refuses dirty source, unknown ignored files, live processes,
+unmerged patches, and unpreserved merge commits. Never force past a refusal.
+Use `ops/dev/worktree.sh --gc` to evaluate finished managed worktrees; it keeps
+anything that fails the same safety checks.

--- a/ops/dev/worktree.sh
+++ b/ops/dev/worktree.sh
@@ -13,6 +13,7 @@ BASE_REF="${BUILDERS_STACK_WORKTREE_BASE:-origin/main}"
 MAX_WORKTREES="${BUILDERS_STACK_MAX_WORKTREES:-8}"
 MAIN_ROOT="$(git -C "$ROOT" worktree list --porcelain | awk '$1 == "worktree" { print substr($0, 10); exit }')"
 WORKTREES_DIR="$(dirname "$MAIN_ROOT")/$(basename "$MAIN_ROOT")-worktrees"
+WT0_BIN="${WORKTREE_ZERO_BIN:-wt0}"
 
 usage() {
   sed -n '2,7p' "$0" | sed 's/^# \{0,1\}//'
@@ -39,6 +40,12 @@ require_supported_bun() {
   actual="$(bun --version 2>/dev/null || true)"
   [[ -n "$expected" ]] || die 'package.json has no bun packageManager pin'
   [[ "$actual" == "$expected" ]] || die "Bun $expected is required; found ${actual:-none}. Upgrade before creating a worktree."
+}
+
+require_worktree_zero() {
+  command -v "$WT0_BIN" >/dev/null 2>&1 ||
+    die 'Worktree Zero (wt0) is required. Install it from https://github.com/lonormaly/worktree-zero.'
+  "$WT0_BIN" --help >/dev/null 2>&1 || die "$WT0_BIN is present but cannot start"
 }
 
 managed_path_for_branch() {
@@ -104,7 +111,7 @@ remove_branch_worktree() {
   # only ignored files. A local .env or any unknown ignored file stops cleanup.
   git -C "$dir" clean -ffd -- .builders-stack-worktree node_modules
   git -C "$dir" clean -ffdX
-  git -C "$ROOT" worktree remove "$dir"
+  "$WT0_BIN" remove "$branch"
   rmdir "$WORKTREES_DIR" 2>/dev/null || true
   printf 'removed %s\n' "$dir"
   printf 'kept branch %s; delete it separately with: git branch -d %q\n' "$branch" "$branch"
@@ -133,13 +140,13 @@ case "${1:-}" in
     ;;
   --gc)
     gc_managed_worktrees
-    git -C "$ROOT" worktree prune
+    "$WT0_BIN" prune
     exit 0
     ;;
   --rm)
     [[ -n "${2:-}" ]] || usage
     remove_branch_worktree "$2"
-    git -C "$ROOT" worktree prune
+    "$WT0_BIN" prune
     exit 0
     ;;
   -*) die "unknown option: $1" ;;
@@ -155,6 +162,7 @@ DIR="$WORKTREES_DIR/$SLUG"
 git -C "$ROOT" rev-parse --verify "$BASE_REF^{commit}" >/dev/null 2>&1 ||
   die "$BASE_REF is missing; fetch it before creating a worktree"
 require_supported_bun
+require_worktree_zero
 
 managed_count=0
 if [[ -d "$WORKTREES_DIR" ]]; then
@@ -163,12 +171,11 @@ fi
 ((managed_count < MAX_WORKTREES)) ||
   die "$managed_count managed worktrees already exist (limit $MAX_WORKTREES); finish one and run $SCRIPT --gc"
 
-mkdir -p "$WORKTREES_DIR"
 if git -C "$ROOT" show-ref --verify --quiet "refs/heads/$BRANCH"; then
-  git -C "$ROOT" worktree add "$DIR" "$BRANCH"
-else
-  git -C "$ROOT" worktree add -b "$BRANCH" "$DIR" "$BASE_REF"
+  die "$BRANCH already exists; wt0 safe branch-resume support must land before this wrapper can reopen it"
 fi
+mkdir -p "$WORKTREES_DIR"
+"$WT0_BIN" create "$BRANCH" --path "$DIR" --base "$BASE_REF" --ephemeral >/dev/null
 
 cat >"$DIR/.builders-stack-worktree" <<EOF
 # Created by ops/dev/worktree.sh. The wrapper only removes this checkout when it
@@ -181,6 +188,8 @@ if ! (cd "$DIR" && bun install --frozen-lockfile); then
   printf 'install failed; worktree kept for inspection at %s\n' "$DIR" >&2
   exit 1
 fi
+
+"$WT0_BIN" doctor "$DIR" >/dev/null
 
 if ! find "$DIR/node_modules/.bun" -mindepth 1 -maxdepth 1 -type l -print -quit 2>/dev/null | grep -q .; then
   die 'Bun did not create global-store links; do not continue with a full per-worktree node_modules copy'

--- a/ops/dev/worktree.test.ts
+++ b/ops/dev/worktree.test.ts
@@ -64,6 +64,36 @@ exit 64
 `,
   );
   chmodSync(join(fakeBin, "bun"), 0o755);
+  writeFileSync(
+    join(fakeBin, "wt0"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "\${1:-}" in
+  --help) exit 0 ;;
+  create)
+    branch="$2"; shift 2; target=""; base="HEAD"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --path) target="$2"; shift 2 ;;
+        --base) base="$2"; shift 2 ;;
+        --ephemeral) shift ;;
+        *) exit 64 ;;
+      esac
+    done
+    git worktree add -b "$branch" "$target" "$base" >/dev/null
+    ;;
+  doctor) exit 0 ;;
+  remove)
+    branch="$2"
+    target="$(git worktree list --porcelain | awk -v wanted="refs/heads/$branch" '$1 == "worktree" { path = substr($0, 10) } $1 == "branch" && $2 == wanted { print path; exit }')"
+    git worktree remove "$target"
+    ;;
+  prune) git worktree prune ;;
+  *) exit 64 ;;
+esac
+`,
+  );
+  chmodSync(join(fakeBin, "wt0"), 0o755);
 
   git(fixture, "init", "--bare", remote);
   git(fixture, "init", "-b", "main", repo);

--- a/scripts/check-worktrees.ts
+++ b/scripts/check-worktrees.ts
@@ -32,6 +32,9 @@ requireText(".github/workflows/ci.yml", /bun-version: 1\.3\.14/, "run the pinned
 requireText("AGENTS.md", /ops\/dev\/worktree\.sh <branch>/, "require the managed worktree wrapper");
 requireText("CLAUDE.md", /ops\/dev\/worktree\.sh <branch>/, "mirror the managed worktree rule");
 requireText("ops/dev/worktree.sh", /bun install --frozen-lockfile/, "install reproducibly");
+requireText("ops/dev/worktree.sh", /"\$WT0_BIN" create/, "create source through Worktree Zero");
+requireText("ops/dev/worktree.sh", /"\$WT0_BIN" doctor/, "verify runtime through Worktree Zero");
+requireText("ops/dev/worktree.sh", /"\$WT0_BIN" remove/, "remove through Worktree Zero");
 requireText(
   "ops/dev/worktree.sh",
   /git -C "\$ROOT" cherry "\$BASE_REF"/,
@@ -43,6 +46,9 @@ if ((statSync(resolve(root, "ops/dev/worktree.sh")).mode & 0o111) === 0) {
 }
 if (/worktree remove --force/.test(read("ops/dev/worktree.sh"))) {
   failures.push("ops/dev/worktree.sh: forced removal is forbidden");
+}
+if (/git -C "\$ROOT" worktree (add|remove)/.test(read("ops/dev/worktree.sh"))) {
+  failures.push("ops/dev/worktree.sh: raw Git lifecycle must stay behind Worktree Zero");
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Summary

Builders Stack becomes the first downstream Worktree Zero consumer. Its project wrapper keeps the existing merge, dirty-file, live-process, ignored-file and worktree-count policies, while source creation, doctor verification, removal and pruning now go through the single `wt0` binary.

The portable `create-a-worktree` skill has one source under `agents/skills` and is exposed to both Codex and Claude through symlinks.

## Measured proof

- checkout for this PR was itself created by `wt0` in CoW mode
- source checkout physical allocation: 3,728 KiB
- cold downstream bootstrap: 46.839s / 514,420 KiB while populating the shared package store
- subsequent worktree: 49,928 KiB physical; teardown reclaimed 30,216 KiB
- third prepare: 23.944s, with Bun explicitly warning that the 99%-full filesystem is slow

The disk behavior is thin; install time must be remeasured after host disk pressure is relieved.

## Compatibility note

The old wrapper could reopen an existing branch. Current `wt0 create` safely creates new branches only, so this PR explicitly refuses existing-branch resume instead of falling back to raw Git. Resume support belongs in Worktree Zero and will be added there.

## Test Plan

- [x] `bun run lint` (pre-existing warnings only)
- [x] `bun run check:worktrees` — 2/2 lifecycle tests
- [x] skill validator
- [x] real wrapper → wt0 create → Bun install → doctor → safe remove
- [x] commit lint and format hooks

<!-- immorterm-context -->
## Memory Context

No file-level ImmorTerm history existed for this separate clean checkout. The PR uses current Git diffs and live measurement receipts.

---
Context checked with [ImmorTerm Memory](https://immorterm.com)
<!-- /immorterm-context -->